### PR TITLE
Improve library caching

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,9 +34,17 @@ vid_urls_2 = launches[0].vidURLs
 
 ### Changelog
 
+Since version `1.0.1`, the library is versioned according to Semver.
+
+* 1.0.1 - Improved caching. 
+
 * 1.0 - Changed all fetch calls to be through the Api object. This is a breaking change.
   
+
+  
   ```python
+  # Porting guide
+
   import launchlibrary as ll
   api = ll.Api()
   

--- a/launchlibrary/network.py
+++ b/launchlibrary/network.py
@@ -27,7 +27,6 @@ class Network:
 
         :param endpoint:  The api endpoint
         :param data:  A dict containing data for the request
-        :param options: NetworkOptions for the request
         :return:  response dict.
         """
         request_url = self._get_url(endpoint, data)
@@ -68,3 +67,7 @@ class Network:
             raise ll_exceptions.NetworkException(str(e))
 
         return resp_dict  # Returns a json style object of the response.
+
+    # For lru_cache. We're not hashing the sess because it doesn't affect responses
+    def __hash__(self):
+        return hash((self.url, self.mode))

--- a/setup.py
+++ b/setup.py
@@ -5,7 +5,7 @@ with open("README.md", "r") as fh:
 
 setuptools.setup(
     name="python-launch-library",
-    version="1",
+    version="1.0.1",
     author="Nir Harel",
     author_email="nir@nirharel.dev",
     description="A wrapper for the launchlibrary.net API",


### PR DESCRIPTION
The library used to differentiate between caches according to the actual object. This is wasteful - for example, pads would be fetched twice for two separate `Rocket` objects. The caching is now based solely upon the version of the API, API endpoint, and the relevant parameter.